### PR TITLE
Backtrack to console-kit 3.1.1, reap benefits

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "console-kit",
-        "repositoryURL": "https://github.com/jsbean/console-kit",
+        "package": "Console",
+        "repositoryURL": "https://github.com/vapor/console-kit",
         "state": {
-          "branch": "master",
-          "revision": "33dad2ed56196bf999ad10d433d34ee16c0ec9d2",
-          "version": null
+          "branch": null,
+          "revision": "74cfbea629d4aac34a97cead2447a6870af1950b",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "package": "Core",
+        "repositoryURL": "https://github.com/vapor/core.git",
+        "state": {
+          "branch": null,
+          "revision": "c64f63cb21631010952f7abfef719d376ab6a441",
+          "version": "3.9.1"
         }
       },
       {
@@ -47,6 +56,15 @@
         }
       },
       {
+        "package": "Service",
+        "repositoryURL": "https://github.com/vapor/service.git",
+        "state": {
+          "branch": null,
+          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "Structure",
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
@@ -56,12 +74,21 @@
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "f4240bf022a69815241a883c03645444b58ac553",
-          "version": "1.1.0"
+          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
+          "version": "1.14.1"
+        }
+      },
+      {
+        "package": "swift-nio-zlib-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
+        "state": {
+          "branch": null,
+          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,12 @@ let package = Package(
         .package(url: "https://github.com/dn-m/Music", from: "0.15.0"),
         .package(url: "https://github.com/dn-m/NotationModel", from: "0.8.0"),
         .package(url: "https://github.com/dn-m/Math", from: "0.7.1"),
-        .package(url: "https://github.com/jsbean/console-kit", .branch("master"))
+        .package(url: "https://github.com/vapor/console-kit", .upToNextMinor(from: "3.1.1"))
     ],
     targets: [
         .target(
             name: "harmonic-network",
-            dependencies: ["DataStructures", "Pitch", "Math", "SpelledPitch", "ConsoleKit"]
+            dependencies: ["DataStructures", "Pitch", "Math", "SpelledPitch", "Console", "Logging", "Command"]
         ),
         .testTarget(
             name: "HarmonicPathfinderTests",

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Find your way through a network of harmony.
 
 #### Usage
 
-Run the `find-path` command
+Once you have [built the executable](#Installation), run the `harmonic-network` program by calling it up from the `.build/debug` directory
 
 ```bash
-./.build/debug/harmonic-network find-path
+./.build/debug/harmonic-network
 ```
 
 You will start on the `Tonic` (`I`) chord, and you will be prompted to choose the next chord from a list of options.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ All done: ["I", "IV6", "V6", "vi", "ii", "V", "I"]
 Furthermore, you have the option of `undo`-ing and `redo`-ing any choices that you have made. Kids today have it so easy.
 
 
-##### `--oneshot (-o)`
+##### `--one-shot (-o)`
 
-The `--oneshot` flag (`-o` for short) tells the program that you only want to create a single tonic progression. That is to say, as soon as you get to the tonic (`I`) chord again, the game's up.
+The `--one-shot` flag (`-o` for short) tells the program that you only want to create a single tonic progression. That is to say, as soon as you get to the tonic (`I`) chord again, the game's up.
 
-If you don't call the `--oneshot` flag, you will choose new harmonies for the rest of eternity, or until you select the `done` option, your laptop battery runs out, or until the heat death of the universe. Your call.
+If you don't call the `--one-shot` flag, you will choose new harmonies for the rest of eternity, or until you select the `done` option, your laptop battery runs out, or until the heat death of the universe. Your call.
 
 ##### Installation
 


### PR DESCRIPTION
This PR reduces the version of `console-kit` to the significantly less bleeding edge version `3.1.1`., thus reducing the dependency on very specific Swift toolchains and therefore operating systems and Xcode versions.

While not being quite as cool w/r/t using property wrappers, etc., it re-allows us to use the name `one-shot` rather than `oneshot`. This is because the `4.0.0-alphas` introspect on a `Command`'s property names rather than having them set manually via a `String`. In the end, this will be good, but there needs to be an intervening step similar to that of the `Coding` universe's `convert(To|From)KebabCase`, or `CodingKeys` customization.

The `4.0.0-alpha` versions also don't currently respect the `default` command (in this case `find-path`), making the user type (and know about) extra stuff which they might not need to.